### PR TITLE
Update ShowDemo.psd1 FunctionsToExport for lazy module loading

### DIFF
--- a/ShowDemo.psd1
+++ b/ShowDemo.psd1
@@ -6,6 +6,9 @@
     Guid             = 'c4516317-f99e-44cf-b138-d8c4d1eadf66'
     ModuleVersion    = '0.1.7'
     RootModule       = 'ShowDemo.psm1'
+    FunctionsToExport = @(
+        '*-Demo'
+    )
     FormatsToProcess = 'ShowDemo.format.ps1xml'
     TypesToProcess   = 'ShowDemo.types.ps1xml'        
     PrivateData      = @{


### PR DESCRIPTION
Adding this simple change allows me to not have to run Import-Module before running
the awesome functions in this module.
Perhaps this would export more that you want to from this module.

Using function names not ending in -Demo would not be exported
